### PR TITLE
[BLOG] Add padding for the language link in the navbar for websites

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -312,7 +312,7 @@ add_link <- function(path, main_language = main_language, language_code, site_ur
     xml2::xml_add_child(
       navbar,
       "a",
-      style = "text-decoration: none; color: inherit; padding-right: 5px;",
+      style = "text-decoration: none; color: inherit; padding: 0.5em;",
       version_text,
       class = "nav-item",
       href = href,

--- a/R/render.R
+++ b/R/render.R
@@ -312,7 +312,7 @@ add_link <- function(path, main_language = main_language, language_code, site_ur
     xml2::xml_add_child(
       navbar,
       "a",
-      style = "text-decoration: none; color:inherit;",
+      style = "text-decoration: none; color: inherit; padding-right: 5px;",
       version_text,
       class = "nav-item",
       href = href,


### PR DESCRIPTION
Hi @maelle !
This is a suggestion, but I'm not sure if this is the best way to make this fix.
When the function `add_link()` executes, I added a style to give a little space so the language names are not glued together. 

- Before:
<img width="628" alt="imagem" src="https://github.com/ropensci-review-tools/babelquarto/assets/42153618/62801c6c-37a3-4af1-b280-b77543057eaa">

- After:
<img width="521" alt="imagem" src="https://github.com/ropensci-review-tools/babelquarto/assets/42153618/62c633ca-db15-49a2-8fba-61012ce0bc03">