### PR TITLE
[BLOG] Language switch button in blog posts

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -106,7 +106,7 @@ render <- function(path = ".", site_url = NULL, type = c("book", "website")) {
   purrr::walk(
     language_codes,
     ~ purrr::walk(
-      fs::dir_ls(output_folder, glob = "*.html"),
+      fs::dir_ls(output_folder, glob = "*.html", recurse = TRUE),
       add_link,
       main_language = main_language,
       language_code = .x,
@@ -122,7 +122,7 @@ render <- function(path = ".", site_url = NULL, type = c("book", "website")) {
     purrr::walk(
       languages_to_add,
       ~ purrr::walk(
-        fs::dir_ls(file.path(output_folder, other_lang), glob = "*.html"),
+        fs::dir_ls(file.path(output_folder, other_lang), glob = "*.html", recurse = TRUE),
         add_link,
         main_language = main_language,
         language_code = .x,


### PR DESCRIPTION
Hi @maelle !

I noticed that when we have dirs inside the posts folder ([like in this example](https://github.com/beatrizmilz/blog-babel)), it does not show the language switching link in the post.

I'm trying to fix that.
So far, I have made this change:
- when we add the link, we need to use dir_ls. I added the argument `recurse=TRUE`, so it can find the files inside other folders.




- Before:
<img width="992" alt="imagem" src="https://github.com/ropensci-review-tools/babelquarto/assets/42153618/41394488-3291-491c-a206-a6002a279122">

- After:
<img width="1076" alt="imagem" src="https://github.com/ropensci-review-tools/babelquarto/assets/42153618/cb6b6000-c9fb-444a-9a8f-931d82af34b2">


But now, the link appears, but the URL is not correct. Ex:
```
docs/posts/2019-08-12-tidydevday//en/index.html
```
(I'm testing locally)

The correct link should be:
```
docs/en/posts/2019-08-12-tidydevday/index.en.html
```

I'm still trying to figure this out, so I leave this PR as a draft :) 
