### PR TITLE
fix: language menu in books with navbar

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -341,18 +341,18 @@ add_link <- function(path, main_language = main_language,
 
   if (type == "book") {
 
-    logo <- xml2::xml_find_first(html, "//div[contains(@class,'sidebar-header')]")
+    sidebar_menu <- xml2::xml_find_first(html, "//div[contains(@class,'sidebar-menu-container')]")
 
     languages_links <- xml2::xml_find_first(html, "//ul[@id='languages-links']")
     languages_links_div_exists <- (length(languages_links) > 0)
 
     if (!languages_links_div_exists) {
       xml2::xml_add_sibling(
-        logo,
+        sidebar_menu,
         "div",
         class = "dropdown",
         id = "languages-links-parent",
-        .where = "after"
+        .where = "before"
       )
 
       parent <- xml2::xml_find_first(html, "//div[@id='languages-links-parent']")


### PR DESCRIPTION
Fix #51 

This is my attempt to fix the issue with the language menu not showing when there's a navbar in quarto books.

It now works in both cases (with and without the navbar). The location of the language menu is slightly different in books without the navbar: the menu now shows below the search bar instead of above. I don't see this as an issue, but if you wish to keep the location exactly as before, I'd have to do some further research to find the "ideal" insertion point.