### PR TITLE
feat: allow subtitle translation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,8 @@ Authors@R: c(
     person("Johannes", "Ranke", role = "ctb"),
     person("Joel H.", "Nitta", , "joelnitta@gmail.com", role = "ctb",
            comment = c(ORCID = "0000-0003-4719-7472")),
-    person("Pascal", "Burkhard", role = "ctb")
+    person("Pascal", "Burkhard", , "pascal.burkhard@gmail.com", role = "aut",
+           comment = c(ORCID = "0009-0001-5504-5084"))
   )
 Description: Automate rendering and cross-linking of Quarto books following a 
     prescribed structure.

--- a/R/render.R
+++ b/R/render.R
@@ -186,6 +186,7 @@ render_quarto_lang <- function(language_code, path, output_dir, type) {
   )
   config$lang <- language_code
   config[[type]][["title"]] <- config[[sprintf("title-%s", language_code)]] %||% config[[type]][["title"]]
+  config[[type]][["subtitle"]] <- config[[sprintf("subtitle-%s", language_code)]] %||% config[[type]][["subtitle"]]
   config[[type]][["description"]] <- config[[sprintf("description-%s", language_code)]] %||% config[[type]][["description"]]
 
   if (type == "book") {


### PR DESCRIPTION
I was looking for the reason why my book's subtitle wasn't translated and saw that this was suggested by @truecluster.
I don't know to which extent adding such translatable options is desired going forward (considering #54 might at some point become the way to go ?), but in the meantime here's a PR.

This closes #55.