### PR TITLE
Merge profiles before the checks

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -296,7 +296,7 @@ use_lang_chapter <- function(chapters_list, language_code,
       language_code = language_code
     )
 
-    if (any(!fs::file_exists(chapters_list[["chapters"]]))) {
+    if (!all(fs::file_exists(chapters_list[["chapters"]]))) {
       chapters_not_translated <- !fs::file_exists(chapters_list[["chapters"]])
       fs::file_move(
         unlist(original_chapters_list[["chapters"]][chapters_not_translated]),

--- a/R/render.R
+++ b/R/render.R
@@ -140,7 +140,8 @@ render <- function(path = ".",
       type = type,
       config = config_contents,
       output_folder = output_folder,
-      path_language = main_language
+      path_language = main_language,
+      project_dir = path
     )
   )
   purrr::walk(
@@ -170,7 +171,8 @@ render <- function(path = ".",
         type = type,
         config = config_contents,
         output_folder = output_folder,
-        path_language = other_lang
+        path_language = other_lang,
+        project_dir = path
       )
     )
     purrr::walk(
@@ -329,10 +331,18 @@ use_lang_chapter <- function(chapters_list, language_code,
 
 add_links <- function(path, main_language, # nolint: cyclocomp_linter
                       language_code, site_url, type, config, output_folder,
-                      path_language) {
+                      path_language, project_dir) {
   html <- xml2::read_html(path)
 
   document_path <- path
+
+  lang_profile <- file.path(
+    project_dir, paste0("_quarto-", language_code, ".yml")
+  )
+  if (fs::file_exists(lang_profile)) {
+    lang_config <- read_yaml(lang_profile)
+    config <- utils::modifyList(config, lang_config)
+  }
 
   codes <- config[["babelquarto"]][["languagecodes"]]
   current_lang <- purrr::keep(codes, ~.x[["name"]] == language_code)

--- a/R/render.R
+++ b/R/render.R
@@ -336,8 +336,9 @@ add_links <- function(path, main_language, # nolint: cyclocomp_linter
 
   document_path <- path
 
-  lang_profile <- file.path(
-    project_dir, paste0("_quarto-", language_code, ".yml")
+  lang_profile <- fs::path(
+    project_dir, paste0("_quarto-", language_code),
+    ext = "yml"
   )
   if (fs::file_exists(lang_profile)) {
     lang_config <- read_yaml(lang_profile)


### PR DESCRIPTION
After the discussion with @joelnitta in #54, I wanted to address the issue of errors raised even when the sidebar/navbar is present in the language profiles only.

Thanks @maelle for the suggestion with `modifyList()`. It works just fine!

I also applied the lintr for `!all()` instead of `any(!)`. In 96669df we had `all()` instead of `!all()` hence the problems with books that have parts.

This PR closes #69.