### PR TITLE
Clarify GitHub Pages project sites and site_url behavior

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,9 @@ Authors@R: c(
     person("Ella", "Kaye", role = "rev",
            comment = c("Ella reviewed the package (v. 0.0.1) for rOpenSci, see <https://github.com/ropensci/software-review/issues/720>.", ORCID = "0000-0002-7300-3718")),
     person("João", "Granja-Correia", role = "rev",
-           comment = c("João reviewed the package (v. 0.0.1) for rOpenSci, see <https://github.com/ropensci/software-review/issues/720>.", ORCID = "0009-0003-8982-278X"))
+           comment = c("João reviewed the package (v. 0.0.1) for rOpenSci, see <https://github.com/ropensci/software-review/issues/720>.", ORCID = "0009-0003-8982-278X")),
+    person("Adam", "Mazel", role = "ctb",
+            comment = c(ORCID = "0000-0001-7241-0891"))
   )
 Description: Automate rendering and cross-linking of Quarto books following a 
     prescribed structure.

--- a/vignettes/babelquarto.qmd
+++ b/vignettes/babelquarto.qmd
@@ -182,6 +182,56 @@ You cannot rely on usual tooling by Quarto because that would only publish the m
 You need to publish the entire output folder, including the language folders.
 [Example workflow using GitHub Pages by committing the output folder to a gh-pages branch](https://github.com/ropensci/dev_guide/blob/6f9d066d0207e83588a4d9c8dabd93e015083e13/.github/workflows/dev.yml#L58).
 
+## Publishing to GitHub Pages project sites
+
+GitHub Pages supports two common types of sites:
+
+- **User sites**, published at  
+  `https://username.github.io/`
+- **Project sites**, published at  
+  `https://username.github.io/repository-name/`
+
+GitHub Pages **project sites** are a very common way to publish Quarto books and websites. However, they require one extra step when working with multilingual projects.
+
+### Rendering locally vs. final website URLs
+
+When you render a multilingual project **locally** (for example, by running `babelquarto::render_book()` or `babelquarto::render_website()` in RStudio), `{babelquarto}` temporarily removes the site URL. This makes local previewing easier, because the site does not yet live at a real web address.
+
+Because of this, links between languages may be written in a form that works locally but does **not** work once the site is published as a GitHub Pages **project site**.
+
+As a result, a multilingual site can look correct during local preview but have broken language links after deployment.
+
+### How to avoid broken language links on project sites
+
+If you are publishing to a GitHub Pages **project site**, you must make sure that `{babelquarto}` knows the final website address *when the site is rendered*. You can do this in one of two ways.
+
+#### Option 1: Render the site using GitHub Actions (CI)
+
+You can let GitHub build the site automatically. In this case, you provide the final website address using the `BABELQUARTO_CI_URL` environment variable.
+
+This approach is recommended for users who are comfortable setting up GitHub Actions. See `vignette("render-with-ci")` for details.
+
+#### Option 2: Specify the site URL when rendering locally
+
+If you prefer to build the site on your own computer, you can pass the site’s URL directly when rendering, even if it is already listed in `_quarto.yml`:
+
+```r
+babelquarto::render_book(
+  site_url = "https://username.github.io/repository-name/"
+)
+```
+
+This ensures that absolute URLs including the repository subpath are generated, and that multilingual navigation works correctly after deployment.
+
+### Summary
+
+- Local renders are designed for previewing and may not include the final website URL.
+- GitHub Pages project sites require the final site URL to be known at render time.
+- To publish a multilingual project correctly to a project site, you must either:
+  - render the site using GitHub Actions, or
+  - provide the site URL when rendering locally..
+- Without one of these steps, multilingual navigation may break after deployment.
+
 ## Next steps
 
 Take a deeper dive into the configuration options available in {babelquarto} and have a look at `vignette("configuration")`.

--- a/vignettes/babelquarto.qmd
+++ b/vignettes/babelquarto.qmd
@@ -152,7 +152,7 @@ Note that the `_quarto.yml` file created in this process has an example entry se
 ## Previewing your multilingual project {#preview}
 
 Once you have rendered your project, you will have a `_site` or `_book` folder in your project.
-In Quarto you would use `quarto preview` to be able to get a look at what you project looks like.
+In Quarto you would use `quarto preview` to get a look at what your project looks like.
 Because of the way {babelquarto} operates, this isn't possible.
 You can however preview your files using the [{servr} package](https://cran.rstudio.com/web/packages/servr/index.html).
 
@@ -182,55 +182,7 @@ You cannot rely on usual tooling by Quarto because that would only publish the m
 You need to publish the entire output folder, including the language folders.
 [Example workflow using GitHub Pages by committing the output folder to a gh-pages branch](https://github.com/ropensci/dev_guide/blob/6f9d066d0207e83588a4d9c8dabd93e015083e13/.github/workflows/dev.yml#L58).
 
-## Publishing to GitHub Pages project sites
-
-GitHub Pages supports two common types of sites:
-
-- **User sites**, published at  
-  `https://username.github.io/`
-- **Project sites**, published at  
-  `https://username.github.io/repository-name/`
-
-GitHub Pages **project sites** are a very common way to publish Quarto books and websites. However, they require one extra step when working with multilingual projects.
-
-### Rendering locally vs. final website URLs
-
-When you render a multilingual project **locally** (for example, by running `babelquarto::render_book()` or `babelquarto::render_website()` in RStudio), `{babelquarto}` temporarily removes the site URL. This makes local previewing easier, because the site does not yet live at a real web address.
-
-Because of this, links between languages may be written in a form that works locally but does **not** work once the site is published as a GitHub Pages **project site**.
-
-As a result, a multilingual site can look correct during local preview but have broken language links after deployment.
-
-### How to avoid broken language links on project sites
-
-If you are publishing to a GitHub Pages **project site**, you must make sure that `{babelquarto}` knows the final website address *when the site is rendered*. You can do this in one of two ways.
-
-#### Option 1: Render the site using GitHub Actions (CI)
-
-You can let GitHub build the site automatically. In this case, you provide the final website address using the `BABELQUARTO_CI_URL` environment variable.
-
-This approach is recommended for users who are comfortable setting up GitHub Actions. See `vignette("render-with-ci")` for details.
-
-#### Option 2: Specify the site URL when rendering locally
-
-If you prefer to build the site on your own computer, you can pass the site’s URL directly when rendering, even if it is already listed in `_quarto.yml`:
-
-```r
-babelquarto::render_book(
-  site_url = "https://username.github.io/repository-name/"
-)
-```
-
-This ensures that absolute URLs including the repository subpath are generated, and that multilingual navigation works correctly after deployment.
-
-### Summary
-
-- Local renders are designed for previewing and may not include the final website URL.
-- GitHub Pages project sites require the final site URL to be known at render time.
-- To publish a multilingual project correctly to a project site, you must either:
-  - render the site using GitHub Actions, or
-  - provide the site URL when rendering locally..
-- Without one of these steps, multilingual navigation may break after deployment.
+For details on local rendering and publishing to GitHub Pages project sites, see `vignette("local-render")`.
 
 ## Next steps
 

--- a/vignettes/local-render.qmd
+++ b/vignettes/local-render.qmd
@@ -12,35 +12,26 @@ GitHub Pages supports [two common types of sites](https://docs.github.com/en/pag
   `https://username.github.io/repository-name/`
 
 GitHub Pages **project sites** are a very common way to publish Quarto books and websites. 
-
 However, they require one extra step when working with multilingual projects.
-
 The same issue can also occur on other hosting platforms where a site is published under a subpath rather than at the root of the domain.
 
 ### Rendering locally vs. final website URLs
 
 When you render a multilingual project **locally** (for example, by running `babelquarto::render_book()` or `babelquarto::render_website()` in RStudio IDE or Positron IDE), `{babelquarto}` temporarily removes the site URL. 
-
 This makes local previewing easier, because the site does not yet live at a real web address.
-
 Because of this, links between languages may be written in a form that works locally but does **not** work once the site is published under a subpath, such as a GitHub Pages **project site**.
-
 As a result, a multilingual site can look correct during local preview but have broken language links after deployment.
 
 ### How to avoid broken language links on subpath-based sites
 
 If your site is served under a subpath (including GitHub Pages project sites), `{babelquarto}` must know the final website address when the site is rendered.
-
 You can do this in one of two ways.
 
 #### Option 1: Render the site using GitHub Actions (CI)
 
 You can let GitHub build the site automatically. 
-
 In this case, you provide the final website address using the `BABELQUARTO_CI_URL` environment variable.
-
 This approach is recommended for users who are comfortable setting up GitHub Actions. 
-
 See `vignette("render-with-ci")` for details.
 
 #### Option 2: Specify the site URL when rendering locally

--- a/vignettes/local-render.qmd
+++ b/vignettes/local-render.qmd
@@ -1,0 +1,65 @@
+---
+title: "Local rendering and publishing to subpath-based sites"
+---
+
+## Publishing to project sites and other subpath-based hosting
+
+GitHub Pages supports [two common types of sites](https://docs.github.com/en/pages/getting-started-with-github-pages/what-is-github-pages#types-of-github-pages-sites):
+
+- **User sites**, published at  
+  `https://username.github.io/`
+- **Project sites**, published at  
+  `https://username.github.io/repository-name/`
+
+GitHub Pages **project sites** are a very common way to publish Quarto books and websites. 
+
+However, they require one extra step when working with multilingual projects.
+
+The same issue can also occur on other hosting platforms where a site is published under a subpath rather than at the root of the domain.
+
+### Rendering locally vs. final website URLs
+
+When you render a multilingual project **locally** (for example, by running `babelquarto::render_book()` or `babelquarto::render_website()` in RStudio IDE or Positron IDE), `{babelquarto}` temporarily removes the site URL. 
+
+This makes local previewing easier, because the site does not yet live at a real web address.
+
+Because of this, links between languages may be written in a form that works locally but does **not** work once the site is published under a subpath, such as a GitHub Pages **project site**.
+
+As a result, a multilingual site can look correct during local preview but have broken language links after deployment.
+
+### How to avoid broken language links on subpath-based sites
+
+If your site is served under a subpath (including GitHub Pages project sites), `{babelquarto}` must know the final website address when the site is rendered.
+
+You can do this in one of two ways.
+
+#### Option 1: Render the site using GitHub Actions (CI)
+
+You can let GitHub build the site automatically. 
+
+In this case, you provide the final website address using the `BABELQUARTO_CI_URL` environment variable.
+
+This approach is recommended for users who are comfortable setting up GitHub Actions. 
+
+See `vignette("render-with-ci")` for details.
+
+#### Option 2: Specify the site URL when rendering locally
+
+If you prefer to build the site on your own computer, you can pass the site’s URL directly when rendering, even if it is already listed in `_quarto.yml`:
+
+```r
+babelquarto::render_book(
+  site_url = "https://username.github.io/repository-name/"
+)
+```
+
+This ensures that absolute URLs including the repository subpath are generated, and that multilingual navigation works correctly after deployment.
+
+### Summary
+
+- Local renders are designed for previewing and may not include the final website URL.
+- Sites served under a subpath (including GitHub Pages project sites) require the final site URL to be known at render time.
+- To publish a multilingual project correctly to a site served under a subpath, you must either:
+  - render the site using GitHub Actions, or
+  - provide the site URL when rendering locally.
+- Without one of these steps, multilingual navigation may break after deployment.

--- a/vignettes/local-render.qmd
+++ b/vignettes/local-render.qmd
@@ -1,5 +1,11 @@
 ---
 title: "Local rendering and publishing to subpath-based sites"
+description: >
+  How to render projects locally
+vignette: >
+  %\VignetteIndexEntry{Render locally}
+  %\VignetteEngine{quarto::html}
+  %\VignetteEncoding{UTF-8}
 ---
 
 ## Publishing to project sites and other subpath-based hosting


### PR DESCRIPTION
Added guidelines for publishing multilingual sites to GitHub Pages, including options for rendering with GitHub Actions or specifying the site URL locally.