### PR TITLE
work with Jupyter notebooks in different human languages

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -116,7 +116,7 @@ render <- function(
   profile <- profile %||% Sys.getenv("QUARTO_PROFILE")
   fs::dir_copy(path, temporary_directory)
   withr::with_dir(file.path(temporary_directory, fs::path_file(path)), {
-    fs::file_delete(fs::dir_ls(regexp = "\\...\\.qmd", recurse = TRUE))
+    fs::file_delete(fs::dir_ls(regexp = "\\...\\.qmd|\\...\\.ipynb", recurse = TRUE))
     metadata <- list("true")
     names(metadata) <- sprintf("lang-%s", main_language)
     quarto::quarto_render(
@@ -341,22 +341,33 @@ render_quarto_lang <- function(
   }
 
   if (type == "website") {
-    # only keep what's needed
+    # only keep what's needed, includes .qmd & .ipynb files
     qmds <- fs::dir_ls(
       file.path(temporary_directory, fs::path_file(path)),
-      glob = "*.qmd",
+      glob = "*.qmd|*.ipynb",
       recurse = TRUE
     )
     language_qmds <- purrr::keep(
       qmds,
-      \(x) endsWith(x, sprintf(".%s.qmd", language_code))
+      \(x) any(
+        # both qmd & ipynb files are accepted
+        endsWith(x, sprintf(".%s.qmd", language_code)),
+        endsWith(x, sprintf(".%s.ipynb", language_code))
+      )
     )
     fs::file_delete(qmds[!(qmds %in% language_qmds)])
     for (qmd_path in language_qmds) {
+      # ensure that files are moved correctl, depending on ending
+      if (endsWith(qmd_path, ".qmd")){
       fs::file_move(
         qmd_path,
         sub(sprintf("%s.qmd", language_code), "qmd", qmd_path)
-      )
+      )}
+      else {
+      fs::file_move(
+        qmd_path,
+        sub(sprintf("%s.ipynb", language_code), "ipynb", qmd_path)
+      )}
     }
     # Replace TRUE and FALSE with 'true' and 'false'
     # to avoid converting to "yes" and "no"

--- a/R/render.R
+++ b/R/render.R
@@ -116,7 +116,7 @@ render <- function(
   profile <- profile %||% Sys.getenv("QUARTO_PROFILE")
   fs::dir_copy(path, temporary_directory)
   withr::with_dir(file.path(temporary_directory, fs::path_file(path)), {
-    fs::file_delete(fs::dir_ls(regexp = "\\...\\.qmd|\\...\\.ipynb", recurse = TRUE))
+    fs::file_delete(fs::dir_ls(regexp = "\\...\\.qmd|\\...\\.Rmd|\\...\\.ipynb", recurse = TRUE))
     metadata <- list("true")
     names(metadata) <- sprintf("lang-%s", main_language)
     quarto::quarto_render(
@@ -344,29 +344,34 @@ render_quarto_lang <- function(
     # only keep what's needed, includes .qmd & .ipynb files
     qmds <- fs::dir_ls(
       file.path(temporary_directory, fs::path_file(path)),
-      glob = "*.qmd|*.ipynb",
+      glob = "*.qmd|*.Rmd|*.ipynb",
       recurse = TRUE
     )
-    language_qmds <- purrr::keep(
+    language_files <- purrr::keep(
       qmds,
       \(x) any(
-        # both qmd & ipynb files are accepted
         endsWith(x, sprintf(".%s.qmd", language_code)),
+        endsWith(x, sprintf(".%s.Rmd", language_code)),
         endsWith(x, sprintf(".%s.ipynb", language_code))
       )
     )
-    fs::file_delete(qmds[!(qmds %in% language_qmds)])
-    for (qmd_path in language_qmds) {
+    fs::file_delete(qmds[!(qmds %in% language_files)])
+    for (file_path in language_files) {
       # ensure that files are moved correctl, depending on ending
-      if (endsWith(qmd_path, ".qmd")){
+      if (endsWith(file_path, ".qmd")){
       fs::file_move(
-        qmd_path,
-        sub(sprintf("%s.qmd", language_code), "qmd", qmd_path)
+        file_path,
+        sub(sprintf("%s.qmd", language_code), "qmd", file_path)
       )}
+      else if (endsWith(file_path, ".Rmd")){
+        fs::file_move(
+          file_path,
+          sub(sprintf("%s.Rmd", language_code), "Rmd", file_path)
+        )}
       else {
       fs::file_move(
-        qmd_path,
-        sub(sprintf("%s.ipynb", language_code), "ipynb", qmd_path)
+        file_path,
+        sub(sprintf("%s.ipynb", language_code), "ipynb", file_path)
       )}
     }
     # Replace TRUE and FALSE with 'true' and 'false'

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,11 +27,13 @@ lang_code_chapter_list <- function(chapters_list, language_code) {
     chapters_list
   )
 
-  gsub(
+  chapters_list <- gsub(
     "\\.ipynb", # nolint: fixed_regex_linter
     sprintf(".%s.ipynb", language_code),
     chapters_list
   )
+
+  return(chapters_list)
 }
 
 trim_end <- function(config_lines) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,9 +21,15 @@ lang_code_chapter_list <- function(chapters_list, language_code) {
     chapters_list
   )
 
-  gsub(
+  chapters_list <- gsub(
     "\\.qmd", # nolint: fixed_regex_linter
     sprintf(".%s.qmd", language_code),
+    chapters_list
+  )
+
+  gsub(
+    "\\.ipynb", # nolint: fixed_regex_linter
+    sprintf(".%s.ipynb", language_code),
     chapters_list
   )
 }

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -385,16 +385,37 @@ test_that("render_website() works - clean render for each language", {
     file.path(parent_dir, project_dir, "about.fr.qmd"),
     file.path(parent_dir, project_dir, "subdir", "about.fr.qmd")
   )
+  fs::file_copy(
+    test_path("test_files/jupyter-notebook.ipynb"),
+    file.path(parent_dir, project_dir, "subdir")
+  )
+  fs::file_copy(
+    test_path("test_files/jupyter-notebook.fr.ipynb"),
+    file.path(parent_dir, project_dir, "subdir")
+  )
+  fs::file_copy(
+    test_path("test_files/rmarkdown.Rmd"),
+    file.path(parent_dir, project_dir, "subdir")
+  )
+  fs::file_copy(
+    test_path("test_files/rmarkdown.fr.Rmd"),
+    file.path(parent_dir, project_dir, "subdir")
+  )
 
   withr::with_dir(parent_dir, render_website(project_dir))
   main_subdir <- file.path(parent_dir, project_dir, "_site", "subdir")
   expect_dir_exists(main_subdir)
-  expect_length(fs::dir_ls(main_subdir), 1L)
+  expect_length(fs::dir_ls(main_subdir), 3L)
+  expect_file_exists(file.path(main_subdir, "jupyter-notebook.html"))
+  expect_file_exists(file.path(main_subdir, "rmarkdown.html"))
+
 
   french_subdir <- file.path(parent_dir, project_dir, "_site", "fr", "subdir")
   expect_dir_exists(french_subdir)
-  expect_length(fs::dir_ls(french_subdir), 1L)
+  expect_length(fs::dir_ls(french_subdir), 3L)
   expect_file_exists(file.path(french_subdir, "about.html"))
+  expect_file_exists(file.path(french_subdir, "jupyter-notebook.html"))
+  expect_file_exists(file.path(french_subdir, "rmarkdown.html"))
 
   spanish_subdir <- file.path(parent_dir, project_dir, "_site", "es", "subdir")
   expect_dir_absent(spanish_subdir)

--- a/tests/testthat/test_files/jupyter-notebook.fr.ipynb
+++ b/tests/testthat/test_files/jupyter-notebook.fr.ipynb
@@ -1,0 +1,51 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3a7f40e5-ccfe-45e5-8a89-fcd32edfbe4c",
+   "metadata": {},
+   "source": [
+    "# Test notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4ecdf455-0e36-4e78-abff-1e9d34817c8b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tested\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('tested')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/testthat/test_files/jupyter-notebook.ipynb
+++ b/tests/testthat/test_files/jupyter-notebook.ipynb
@@ -1,0 +1,51 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3a7f40e5-ccfe-45e5-8a89-fcd32edfbe4c",
+   "metadata": {},
+   "source": [
+    "# Test notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4ecdf455-0e36-4e78-abff-1e9d34817c8b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tested\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('tested')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/testthat/test_files/rmarkdown.Rmd
+++ b/tests/testthat/test_files/rmarkdown.Rmd
@@ -1,0 +1,5 @@
+---
+title: "rmarkdown"
+output: html_document
+---
+

--- a/tests/testthat/test_files/rmarkdown.fr.Rmd
+++ b/tests/testthat/test_files/rmarkdown.fr.Rmd
@@ -1,0 +1,5 @@
+---
+title: "rmarkdown"
+output: html_document
+---
+


### PR DESCRIPTION
This would directly address and close #125 by adding support for correctly rendering Jupyter notebooks that are available in multiple human languages (e.g. as  `test.ipynb`, `test.de.ipynb` and `test.es.ipynb`).

A very small WIP example is at https://gedankenstuecke.github.io/quarto_multiling_teaching_website/pywikibot-examples.html, which was created by running `render_website` from this branch.

So far, I have not adapted the `quarto_multilingual_project` function to automatically create ipynb files when running that command, and I haven't touched the test suite - but happy to add both things if this is generally deemed worth of inclusion.[^1] :slightly_smiling_face:  

[^1]: I just went ahead making the changes as I wanted to scratch my own itch for making working with jupyter notebooks for my use case easier right away, and thought I could also just raise it as a PR already 