### PR TITLE
fix: behavior for `CNAME` files & related docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # babelquarto (development version)
 
 - Add support for language-specific abstract in books
+- Fix and document behavior for `CNAME` files (#120, @luisDVA)
 
 # babelquarto 0.1.0
 

--- a/R/render.R
+++ b/R/render.R
@@ -116,7 +116,10 @@ render <- function(
   profile <- profile %||% Sys.getenv("QUARTO_PROFILE")
   fs::dir_copy(path, temporary_directory)
   withr::with_dir(file.path(temporary_directory, fs::path_file(path)), {
-    fs::file_delete(fs::dir_ls(regexp = "\\...\\.qmd|\\...\\.Rmd|\\...\\.ipynb", recurse = TRUE))
+    fs::file_delete(fs::dir_ls(
+      regexp = "\\...\\.qmd|\\...\\.Rmd|\\...\\.ipynb",
+      recurse = TRUE
+    ))
     metadata <- list("true")
     names(metadata) <- sprintf("lang-%s", main_language)
     quarto::quarto_render(
@@ -349,30 +352,33 @@ render_quarto_lang <- function(
     )
     language_files <- purrr::keep(
       qmds,
-      \(x) any(
-        endsWith(x, sprintf(".%s.qmd", language_code)),
-        endsWith(x, sprintf(".%s.Rmd", language_code)),
-        endsWith(x, sprintf(".%s.ipynb", language_code))
-      )
+      \(x) {
+        any(
+          endsWith(x, sprintf(".%s.qmd", language_code)),
+          endsWith(x, sprintf(".%s.Rmd", language_code)),
+          endsWith(x, sprintf(".%s.ipynb", language_code))
+        )
+      }
     )
     fs::file_delete(qmds[!(qmds %in% language_files)])
     for (file_path in language_files) {
       # ensure that files are moved correctl, depending on ending
-      if (endsWith(file_path, ".qmd")){
-      fs::file_move(
-        file_path,
-        sub(sprintf("%s.qmd", language_code), "qmd", file_path)
-      )}
-      else if (endsWith(file_path, ".Rmd")){
+      if (endsWith(file_path, ".qmd")) {
+        fs::file_move(
+          file_path,
+          sub(sprintf("%s.qmd", language_code), "qmd", file_path)
+        )
+      } else if (endsWith(file_path, ".Rmd")) {
         fs::file_move(
           file_path,
           sub(sprintf("%s.Rmd", language_code), "Rmd", file_path)
-        )}
-      else {
-      fs::file_move(
-        file_path,
-        sub(sprintf("%s.ipynb", language_code), "ipynb", file_path)
-      )}
+        )
+      } else {
+        fs::file_move(
+          file_path,
+          sub(sprintf("%s.ipynb", language_code), "ipynb", file_path)
+        )
+      }
     }
     # Replace TRUE and FALSE with 'true' and 'false'
     # to avoid converting to "yes" and "no"
@@ -394,6 +400,12 @@ render_quarto_lang <- function(
       metadata = metadata,
       profile = language_code
     )
+    # remove CNAME is present
+    # it should only be there for the main language
+    cname_path <- file.path(output_dir, "CNAME")
+    if (file.exists(cname_path)) {
+      file.remove(cname_path)
+    }
   })
 
   # Copy it to local not temporary _book/<language-code>

--- a/tests/testthat/helper-fs.R
+++ b/tests/testthat/helper-fs.R
@@ -9,3 +9,7 @@ expect_file_exists <- function(path) {
 expect_dir_absent <- function(path) {
   testthat::expect_false(fs::dir_exists(path))
 }
+
+expect_file_absent <- function(path) {
+  testthat::expect_false(fs::file_exists(path))
+}

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -7,9 +7,12 @@ test_that("render_book() works", {
     further_languages = c("es", "fr"),
     main_language = "en"
   )
+  file.create(file.path(parent_dir, project_dir, "CNAME"))
 
   withr::with_dir(parent_dir, render_book(project_dir))
   expect_dir_exists(file.path(parent_dir, project_dir, "_book"))
+  expect_file_exists(file.path(parent_dir, project_dir, "_book", "CNAME"))
+  expect_file_absent(file.path(parent_dir, project_dir, "_book", "es", "CNAME"))
 
   index_path <- file.path(parent_dir, project_dir, "_book", "index.html")
   index <- xml2::read_html(index_path)
@@ -408,7 +411,6 @@ test_that("render_website() works - clean render for each language", {
   expect_length(fs::dir_ls(main_subdir), 3L)
   expect_file_exists(file.path(main_subdir, "jupyter-notebook.html"))
   expect_file_exists(file.path(main_subdir, "rmarkdown.html"))
-
 
   french_subdir <- file.path(parent_dir, project_dir, "_site", "fr", "subdir")
   expect_dir_exists(french_subdir)

--- a/vignettes/local-render.qmd
+++ b/vignettes/local-render.qmd
@@ -52,6 +52,11 @@ babelquarto::render_book(
 
 This ensures that absolute URLs including the repository subpath are generated, and that multilingual navigation works correctly after deployment.
 
+### CNAME
+
+If you place a `CNAME` file at the root of your project, Quarto will put it in the output folder.
+babelquarto will ensure it is not present as well in the subdirectories corresponding to different languages.
+
 ### Summary
 
 - Local renders are designed for previewing and may not include the final website URL.

--- a/vignettes/render-with-ci.qmd
+++ b/vignettes/render-with-ci.qmd
@@ -25,6 +25,9 @@ For instance, for GitHub Actions, the workflow would contain these lines:
       BABELQUARTO_CI_URL: <the-url>
 ```
 
+If you place a `CNAME` file at the root of your project, Quarto will put it in the output folder.
+babelquarto will ensure it is not present as well in the subdirectories corresponding to different languages.
+
 ### Steps for rendering
 
 To render your project with CI, you need to follow these general steps:


### PR DESCRIPTION
Fix #120 

@luisDVA Could you please have a look when/if you have time? To test this I also cloned your website's repo, removed CNAME from the docs folder and put it at the root instead, then rendered using babelquarto and checked there was `docs/CNAME` but not `docs/en/CNAME`.